### PR TITLE
Stream per payload

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,9 @@ impl QuicSocket for QuicServer {
         send.write_all(&payload)
             .await
             .map_err(|e| anyhow!("failed to send request: {}", e))?;
+        send.finish()
+            .await
+            .map_err(|e| anyhow!("failed to shutdown stream: {}", e))?;
         Ok(())
     }
 
@@ -124,6 +127,9 @@ impl QuicSocket for QuicClient {
         send.write_all(&payload)
             .await
             .map_err(|e| anyhow!("failed to send request: {}", e))?;
+        send.finish()
+            .await
+            .map_err(|e| anyhow!("failed to shutdown stream: {}", e))?;
         Ok(())
     }
     async fn recv(&mut self, buf: &mut [u8]) -> Result<usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@ impl QuicSocket for QuicServer {
             .write_all(&payload)
             .await
             .map_err(|e| anyhow!("failed to send request: {}", e))?;
-        self.endpoint.wait_idle().await;
         Ok(())
     }
 
@@ -121,7 +120,6 @@ impl QuicSocket for QuicClient {
             .write_all(&payload)
             .await
             .map_err(|e| anyhow!("failed to send request: {}", e))?;
-        self.endpoint.wait_idle().await;
         Ok(())
     }
     async fn recv(&mut self, buf: &mut [u8]) -> Result<usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,77 +1,72 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use futures_util::StreamExt;
-use quinn::{Endpoint, Incoming, ServerConfig};
+use quinn::{Endpoint, RecvStream, SendStream, ServerConfig};
 use std::{error::Error, fs, net::SocketAddr, net::ToSocketAddrs, sync::Arc};
 use url::Url;
 
-pub struct QuicMessage {
-    pub server: QuicServer,
-    pub client: QuicClient,
-}
-
-impl QuicMessage {
-    pub fn new(client: QuicClient, server: QuicServer) -> QuicMessage {
-        QuicMessage { server, client }
-    }
-}
-
 #[async_trait]
 pub trait QuicSocket {
-    fn new(addr: Option<SocketAddr>) -> Self;
+    async fn new(addr: Option<SocketAddr>) -> Self;
     async fn send(&mut self, payload: Vec<u8>) -> Result<()>;
-    async fn recv(&mut self) -> Result<std::vec::Vec<u8>>;
+    async fn recv(&mut self, buf: &mut [u8]) -> Result<usize>;
 }
 
 pub struct QuicServer {
     pub endpoint: Endpoint,
-    pub incoming: Incoming,
+    pub send: SendStream,
+    pub recv: RecvStream,
 }
 
 pub struct QuicClient {
     pub endpoint: Endpoint,
+    pub send: SendStream,
+    pub recv: RecvStream,
 }
 
 #[async_trait]
 impl QuicSocket for QuicServer {
-    fn new(addr: Option<SocketAddr>) -> QuicServer {
+    async fn new(addr: Option<SocketAddr>) -> QuicServer {
         let server_config = configure_server().unwrap();
-        let (endpoint, incoming) = quinn::Endpoint::server(server_config, addr.unwrap()).unwrap();
-        QuicServer { endpoint, incoming }
+        let (endpoint, mut incoming) =
+            quinn::Endpoint::server(server_config, addr.unwrap()).unwrap();
+        let mut send = None;
+        let mut recv = None;
+        while let Some(conn) = incoming.next().await {
+            let quinn::NewConnection { mut bi_streams, .. } = conn.await.unwrap();
+            let (ssend, srecv) = bi_streams.next().await.unwrap().unwrap();
+            send = Some(ssend);
+            recv = Some(srecv);
+            break;
+        }
+        QuicServer {
+            endpoint,
+            send: send.unwrap(),
+            recv: recv.unwrap(),
+        }
     }
     async fn send(&mut self, payload: Vec<u8>) -> Result<()> {
-        while let Some(conn) = self.incoming.next().await {
-            let quinn::NewConnection { mut bi_streams, .. } = conn.await?;
-            while let Some(stream) = bi_streams.next().await {
-                let stream = match stream {
-                    Err(quinn::ConnectionError::ApplicationClosed { .. }) => {
-                        return Ok(());
-                    }
-                    Err(e) => {
-                        return Err(anyhow::Error::new(e));
-                    }
-                    Ok(s) => s,
-                };
-                tokio::spawn(handle_send(stream, payload.clone()));
-                break;
-            }
-            break;
-        }
+        self.send
+            .write_all(&payload)
+            .await
+            .map_err(|e| anyhow!("failed to send request: {}", e))?;
+        self.endpoint.wait_idle().await;
         Ok(())
     }
-    async fn recv(&mut self) -> Result<std::vec::Vec<u8>> {
-        let mut ret = None;
-        while let Some(conn) = self.incoming.next().await {
-            ret = Some(tokio::spawn(handle_connection(conn)).await);
-            break;
-        }
-        Ok(ret.unwrap().unwrap().unwrap())
+
+    async fn recv(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let len = self
+            .recv
+            .read(buf)
+            .await
+            .map_err(|e| anyhow!("failed to read response: {}", e))?;
+        Ok(len.unwrap())
     }
 }
 
 #[async_trait]
 impl QuicSocket for QuicClient {
-    fn new(_addr: Option<SocketAddr>) -> Self {
+    async fn new(_addr: Option<SocketAddr>) -> Self {
         let ca = "cert.der".to_string();
         let mut roots = rustls::RootCertStore::empty();
         roots
@@ -84,16 +79,14 @@ impl QuicSocket for QuicClient {
         client_crypto.alpn_protocols = ALPN_QUIC_HTTP.iter().map(|&x| x.into()).collect();
         let mut endpoint = quinn::Endpoint::client("[::]:0".parse().unwrap()).unwrap();
         endpoint.set_default_client_config(quinn::ClientConfig::new(Arc::new(client_crypto)));
-        QuicClient { endpoint }
-    }
-    async fn send(&mut self, payload: Vec<u8>) -> Result<()> {
         let remote_url = Url::parse("http://127.0.0.1:4442").unwrap();
         let host = Some("localhost".to_string());
         let remote = (
             remote_url.host_str().unwrap(),
             remote_url.port().unwrap_or(4433),
         )
-            .to_socket_addrs()?
+            .to_socket_addrs()
+            .unwrap()
             .next()
             .ok_or_else(|| anyhow!("couldn't resolve to an address"))
             .unwrap();
@@ -101,62 +94,43 @@ impl QuicSocket for QuicClient {
         let host = host
             .as_ref()
             .map_or_else(|| remote_url.host_str(), |x| Some(x))
-            .ok_or_else(|| anyhow!("no hostname specified"))?;
-        let new_conn = self
-            .endpoint
-            .connect(remote, host)?
+            .ok_or_else(|| anyhow!("no hostname specified"))
+            .unwrap();
+        let new_conn = endpoint
+            .connect(remote, host)
+            .unwrap()
             .await
-            .map_err(|e| anyhow!("failed to connect: {}", e))?;
+            .map_err(|e| anyhow!("failed to connect: {}", e))
+            .unwrap();
         let quinn::NewConnection {
             connection: conn, ..
         } = new_conn;
-        let (mut send, _) = conn
+        let (send, recv) = conn
             .open_bi()
             .await
-            .map_err(|e| anyhow!("failed to open stream: {}", e))?;
-        send.write_all(&payload)
+            .map_err(|e| anyhow!("failed to open stream: {}", e))
+            .unwrap();
+        QuicClient {
+            endpoint,
+            send,
+            recv,
+        }
+    }
+    async fn send(&mut self, payload: Vec<u8>) -> Result<()> {
+        self.send
+            .write_all(&payload)
             .await
             .map_err(|e| anyhow!("failed to send request: {}", e))?;
-        send.finish()
-            .await
-            .map_err(|e| anyhow!("failed to shutdown stream: {}", e))?;
-        conn.close(0u32.into(), b"done");
         self.endpoint.wait_idle().await;
         Ok(())
     }
-    async fn recv(&mut self) -> Result<std::vec::Vec<u8>> {
-        let remote_url = Url::parse("http://127.0.0.1:4442").unwrap();
-        let host = Some("localhost".to_string());
-        let remote = (
-            remote_url.host_str().unwrap(),
-            remote_url.port().unwrap_or(4433),
-        )
-            .to_socket_addrs()?
-            .next()
-            .ok_or_else(|| anyhow!("couldn't resolve to an address"))
-            .unwrap();
-
-        let host = host
-            .as_ref()
-            .map_or_else(|| remote_url.host_str(), |x| Some(x))
-            .ok_or_else(|| anyhow!("no hostname specified"))?;
-        let new_conn = self
-            .endpoint
-            .connect(remote, host)?
-            .await
-            .map_err(|e| anyhow!("failed to connect: {}", e))?;
-        let quinn::NewConnection {
-            connection: conn, ..
-        } = new_conn;
-        let (_, recv) = conn
-            .open_bi()
-            .await
-            .map_err(|e| anyhow!("failed to open stream: {}", e))?;
-        let recv_bytes = recv
-            .read_to_end(usize::max_value())
+    async fn recv(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let len = self
+            .recv
+            .read(buf)
             .await
             .map_err(|e| anyhow!("failed to read response: {}", e))?;
-        Ok(recv_bytes)
+        Ok(len.unwrap())
     }
 }
 
@@ -198,52 +172,3 @@ pub fn gen_certificates() -> Result<(), Box<dyn Error>> {
 
 #[allow(unused)]
 pub const ALPN_QUIC_HTTP: &[&[u8]] = &[b"hq-29"];
-
-async fn handle_connection(conn: quinn::Connecting) -> Result<std::vec::Vec<u8>> {
-    Ok(handle_spawn(conn).await.unwrap())
-}
-
-async fn handle_spawn(conn: quinn::Connecting) -> Result<std::vec::Vec<u8>> {
-    let quinn::NewConnection {
-        connection: _,
-        mut bi_streams,
-        ..
-    } = conn.await?;
-    let mut req = None;
-    while let Some(stream) = bi_streams.next().await {
-        let stream = match stream {
-            Err(quinn::ConnectionError::ApplicationClosed { .. }) => {
-                return Ok(vec![]);
-            }
-            Err(e) => {
-                return Err(anyhow::Error::new(e));
-            }
-            Ok(s) => s,
-        };
-        req = Some(tokio::spawn(handle_request(stream)).await?);
-        break;
-    }
-    Ok(req.unwrap())
-}
-
-async fn handle_request((_, recv): (quinn::SendStream, quinn::RecvStream)) -> std::vec::Vec<u8> {
-    let req = recv
-        .read_to_end(64 * 1024)
-        .await
-        .map_err(|e| anyhow!("failed reading request: {}", e))
-        .unwrap();
-    req
-}
-
-async fn handle_send(
-    (mut send, _): (quinn::SendStream, quinn::RecvStream),
-    payload: Vec<u8>,
-) -> Result<()> {
-    send.write_all(&payload)
-        .await
-        .map_err(|e| anyhow!("failed to send response: {}", e))?;
-    send.finish()
-        .await
-        .map_err(|e| anyhow!("failed to shutdown stream: {}", e))?;
-    Ok(())
-}


### PR DESCRIPTION
Move to a model where every payload is sent on a new stream, but on the same connection.

I tested this using the examples in level 4 scripts and the server can do things like receive two separate payloads then send one and the client sends two then receives and all works fine.